### PR TITLE
Add titleColor option to notiflix confirm

### DIFF
--- a/R/use.R
+++ b/R/use.R
@@ -164,6 +164,7 @@ use_notiflix_report <- function(backgroundColor = "#f8f8f8", borderRadius = "25p
 #' @param backOverlay If you don't want to use a colored overlay you can change this option to \code{FALSE}.
 #' @param backOverlayColor Changes the color of the overlay. You can use HEX, RGB or RGBA.
 #' @param titleFontSize Changes the font-size of the title text.
+#' @param titleColor Changes the color of the title text.
 #' @param titleMaxLength Ignores characters of title text after the specified number.
 #' @param messageFontSize Changes the font-size of the message text.
 #' @param messageMaxLength Ignores characters of message text after the specified number.
@@ -186,12 +187,13 @@ use_notiflix_report <- function(backgroundColor = "#f8f8f8", borderRadius = "25p
 #' @importFrom jsonlite toJSON
 use_notiflix_confirm <- function(backgroundColor = "#f8f8f8", borderRadius = "25px",
                                 backOverlay = TRUE, backOverlayColor = "rgba(0,0,0,0.5)",
-                                titleFontSize = "16px", titleMaxLength = 34,
-                                messageFontSize = "13px", messageMaxLength = 400,
-                                buttonsFontSize = "14px", buttonsMaxLength = 34,
-                                okButtonColor = "#f8f8f8", okButtonBackground = "#00b462",
-                                cancelButtonColor = "#f8f8f8", cancelButtonBackground = "#a9a9a9",
-                                cssAnimation = TRUE, cssAnimationDuration = 360,
+                                titleFontSize = "16px", titleColor = "#00b462",
+                                titleMaxLength = 34, messageFontSize = "13px", 
+                                messageMaxLength = 400, buttonsFontSize = "14px",
+                                buttonsMaxLength = 34,okButtonColor = "#f8f8f8", 
+                                okButtonBackground = "#00b462", cancelButtonColor = "#f8f8f8", 
+                                cancelButtonBackground = "#a9a9a9", cssAnimation = TRUE, 
+                                cssAnimationDuration = 360,
                                 cssAnimationStyle = c("fade", "zoom"),
                                 plainText = FALSE, width = "280px") {
   cssAnimationStyle <- match.arg(cssAnimationStyle)
@@ -209,6 +211,7 @@ use_notiflix_confirm <- function(backgroundColor = "#f8f8f8", borderRadius = "25
           backOverlayColor = backOverlayColor,
           titleFontSize = titleFontSize,
           titleMaxLength = titleMaxLength,
+          titleColor = titleColor,
           messageFontSize = messageFontSize,
           messageMaxLength = messageMaxLength,
           buttonsFontSize = buttonsFontSize,

--- a/man/notiflix-confirm.Rd
+++ b/man/notiflix-confirm.Rd
@@ -6,20 +6,37 @@
 \alias{use_notiflix_confirm}
 \title{Confirm dialog with notiflix.js}
 \usage{
-nx_confirm(inputId, title, message = NULL, button_ok = "Ok",
+nx_confirm(
+  inputId,
+  title,
+  message = NULL,
+  button_ok = "Ok",
   button_cancel = "Cancel",
-  session = shiny::getDefaultReactiveDomain())
+  session = shiny::getDefaultReactiveDomain()
+)
 
-use_notiflix_confirm(backgroundColor = "#f8f8f8",
-  borderRadius = "25px", backOverlay = TRUE,
-  backOverlayColor = "rgba(0,0,0,0.5)", titleFontSize = "16px",
-  titleMaxLength = 34, messageFontSize = "13px",
-  messageMaxLength = 400, buttonsFontSize = "14px",
-  buttonsMaxLength = 34, okButtonColor = "#f8f8f8",
-  okButtonBackground = "#00b462", cancelButtonColor = "#f8f8f8",
-  cancelButtonBackground = "#a9a9a9", cssAnimation = TRUE,
-  cssAnimationDuration = 360, cssAnimationStyle = c("fade", "zoom"),
-  plainText = FALSE, width = "280px")
+use_notiflix_confirm(
+  backgroundColor = "#f8f8f8",
+  borderRadius = "25px",
+  backOverlay = TRUE,
+  backOverlayColor = "rgba(0,0,0,0.5)",
+  titleFontSize = "16px",
+  titleColor = "#00b462",
+  titleMaxLength = 34,
+  messageFontSize = "13px",
+  messageMaxLength = 400,
+  buttonsFontSize = "14px",
+  buttonsMaxLength = 34,
+  okButtonColor = "#f8f8f8",
+  okButtonBackground = "#00b462",
+  cancelButtonColor = "#f8f8f8",
+  cancelButtonBackground = "#a9a9a9",
+  cssAnimation = TRUE,
+  cssAnimationDuration = 360,
+  cssAnimationStyle = c("fade", "zoom"),
+  plainText = FALSE,
+  width = "280px"
+)
 }
 \arguments{
 \item{inputId}{The \code{input} slot that will be used to access the value.}
@@ -43,6 +60,8 @@ use_notiflix_confirm(backgroundColor = "#f8f8f8",
 \item{backOverlayColor}{Changes the color of the overlay. You can use HEX, RGB or RGBA.}
 
 \item{titleFontSize}{Changes the font-size of the title text.}
+
+\item{titleColor}{Changes the color of the title text.}
 
 \item{titleMaxLength}{Ignores characters of title text after the specified number.}
 


### PR DESCRIPTION
This PR is in response to the issue #1 

This adds a the argument `titleColor ` to `use_notiflix_confirm()`. 

Before:

```r
shinypop::use_notiflix_confirm(
  okButtonBackground = "#367fa9"
)
#[...]
shinypop::nx_confirm(
  inputId = "confirm",
  title = "Confirm?",
  button_ok = "Confirm",
  button_cancel = "Cancel"
)
```
![1](https://user-images.githubusercontent.com/25507629/94046733-74d98680-fda7-11ea-9203-5756453433fe.PNG)

Now:

```r
shinypop::use_notiflix_confirm(
  okButtonBackground = "#367fa9",
  titleColor = "#367fa9"
)
#[...]
shinypop::nx_confirm(
  inputId = "confirm",
  title = "Confirm?",
  button_ok = "Confirm",
  button_cancel = "Cancel"
)
```

![2](https://user-images.githubusercontent.com/25507629/94046744-799e3a80-fda7-11ea-8e57-06edbe372925.PNG)
